### PR TITLE
fix: Lower min_phantom_version to 6.2.0 (SOARHELP-4570)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publisher: Splunk \
 Connector Version: 2.4.5 \
 Product Vendor: Generic \
 Product Name: SSH \
-Minimum Product Version: 6.2.2
+Minimum Product Version: 6.2.0
 
 This app supports executing various endpoint-based investigative and containment actions on an SSH endpoint
 

--- a/phssh.json
+++ b/phssh.json
@@ -13,7 +13,7 @@
     "logo": "logo_splunk.svg",
     "logo_dark": "logo_splunk_dark.svg",
     "product_version_regex": ".*",
-    "min_phantom_version": "6.2.2",
+    "min_phantom_version": "6.2.0",
     "fips_compliant": true,
     "python_version": "3",
     "latest_tested_versions": [

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 * ** Unreleased **
 
-* fix: Improve failure messages in `get file` action
+* fix: Lower min_phantom_version to 6.2.0


### PR DESCRIPTION
### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- Lowered the `min_phantom_version` from 6.2.2 to 6.2.0, because the reason SSH version 2.4.5 existed at all was to provide a fix to a customer running SOAR 6.2.0

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate
